### PR TITLE
Update certificate paths to use __dirname

### DIFF
--- a/src/modules/auth/certHelper.ts
+++ b/src/modules/auth/certHelper.ts
@@ -7,8 +7,8 @@ import { join } from "path";
  *
  */
 const retrieveCertPaths = {
-  certFile: join(binDir, "certs", "cert.pem"),
-  keyFile: join(binDir, "certs", "key.pem"),
+  certFile: join(__dirname, "certs", "cert.pem"),
+  keyFile: join(__dirname, "certs", "key.pem"),
 };
 
 export { retrieveCertPaths };


### PR DESCRIPTION
Change certificate file paths to utilize __dirname instead of binDir for improved reliability.